### PR TITLE
Add project README and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 KevinRouxERPAC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# ERPAC Website
+
+This repository hosts the source code for **ERPAC**, a company specialised in electronic board design, automation and electrotechnical solutions. The website provides an overview of our services and showcases our know‑how.
+
+## Directory structure
+
+- `css/` – Stylesheets used by all pages
+- `js/` – JavaScript files handling the menu, contact form, map and carousel
+- `images/` – Images organised in subfolders for each section
+- HTML pages (`index.html`, `about.html`, `electronique.html`, etc.)
+- `.github/workflows/` – Continuous deployment configuration
+
+## Deployment with GitHub Actions
+
+A workflow defined in `.github/workflows/deploy.yml` deploys the site automatically via FTP whenever changes are pushed to the `main` branch. The action uses `SamKirkland/FTP-Deploy-Action` and requires the `FTP_PASSWORD` secret to be set in your repository settings.


### PR DESCRIPTION
## Summary
- document project purpose and folder layout in `README.md`
- add MIT license for reuse clarification

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f43d3c2b48322aa3f8b78fd928303