### PR TITLE
Fix automatisme preload filename

### DIFF
--- a/automatisme.html
+++ b/automatisme.html
@@ -14,7 +14,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
     <link rel="preload" as="image" href="images/logos/logo_complet.png">
     <link rel="preload" as="image" href="images/logos/logo_seul.png">
-    <link rel="preload" as="image" href="images/menus/Automatisme.jpeg">
+    <link rel="preload" as="image" href="images/menus/Automatisme.jpg">
     <link rel="preload" as="image" href="images/Automatisme/Automatisme_Etude.png">
     <link rel="preload" as="image" href="images/Automatisme/Automatisme_Conception.jpg">
     <link rel="preload" as="image" href="images/Automatisme/Automatisme_Programmation.webp">


### PR DESCRIPTION
## Summary
- fix preload image extension on `automatisme.html`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686f43f70f408322bd112821a95250f8